### PR TITLE
Fix link to spring-ldap Doc in ldap-repositories.adoc.

### DIFF
--- a/src/main/asciidoc/reference/ldap-repositories.adoc
+++ b/src/main/asciidoc/reference/ldap-repositories.adoc
@@ -225,7 +225,7 @@ public interface PersonRepository extends PagingAndSortingRepository<Person, Str
 === QueryDSL support
 Basic QueryDSL support is included in Spring LDAP. This support includes the following:
 
-*  An Annotation Processor, `LdapAnnotationProcessor`, for generating QueryDSL classes based on Spring LDAP ODM annotations. See http://docs.spring.io/spring-ldap/docs/{springLdapVersion}.RELEASE/reference/#odm[Object-Directory Mapping] for more information on the ODM annotations.
+*  An Annotation Processor, `LdapAnnotationProcessor`, for generating QueryDSL classes based on Spring LDAP ODM annotations. See http://docs.spring.io/spring-ldap/docs/{springLdapVersion}/reference/#odm[Object-Directory Mapping] for more information on the ODM annotations.
 *  A Query implementation, `QueryDslLdapQuery`, for building and executing QueryDSL queries in code.
 *  Spring Data repository support for QueryDSL predicates. `QueryDslPredicateExecutor` includes a number of additional methods with appropriate parameters; extend this interface along with `LdapRepository` to include this support in your repository.
 


### PR DESCRIPTION
Appending .RELEASE was a cause for constructing broken link http://docs.spring.io/spring-ldap/docs/2.3.1.RELEASE.RELEASE/reference/#odm
Check and try the link "Object-Directory Mapping" in http://docs.spring.io/spring-data/ldap/docs/1.0.1.RELEASE/reference/html/#ldap.repo-intro.
