### PR TITLE
Add paging to LdapRepository

### DIFF
--- a/src/main/java/org/springframework/data/ldap/repository/LdapRepository.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapRepository.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 
 import javax.naming.Name;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.ldap.query.LdapQuery;
 
@@ -27,6 +29,7 @@ import org.springframework.ldap.query.LdapQuery;
  *
  * @author Mattias Hellborg Arthursson
  * @author Mark Paluch
+ * @author Houcheng Lin
  */
 public interface LdapRepository<T> extends CrudRepository<T, Name> {
 
@@ -46,4 +49,21 @@ public interface LdapRepository<T> extends CrudRepository<T, Name> {
 	 * @return the entries matching the query.
 	 */
 	Iterable<T> findAll(LdapQuery ldapQuery);
+
+	/**
+	 * Find all entries in the page.
+	 *
+	 * @param pageable the page specification.
+	 * @return the entries matching the query.
+	 */
+	Page<T> findAll(Pageable pageable);
+
+	/**
+	 * Find all entries matching the specified query in the page.
+	 *
+	 * @param ldapQuery the query specification.
+	 * @param pageable the page specification.
+	 * @return the entries matching the query.
+	 */
+	Page<T> findAll(LdapQuery ldapQuery, Pageable pageable);
 }

--- a/src/main/java/org/springframework/data/ldap/repository/support/SimpleLdapRepository.java
+++ b/src/main/java/org/springframework/data/ldap/repository/support/SimpleLdapRepository.java
@@ -23,17 +23,30 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.directory.SearchControls;
 
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.AbstractPageRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Persistable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.ldap.repository.LdapRepository;
 import org.springframework.data.util.Optionals;
 import org.springframework.ldap.NameNotFoundException;
+import org.springframework.ldap.control.PagedResultsCookie;
+import org.springframework.ldap.control.PagedResultsDirContextProcessor;
+import org.springframework.ldap.core.ContextMapper;
+import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.core.support.CountNameClassPairCallbackHandler;
 import org.springframework.ldap.filter.Filter;
+import org.springframework.ldap.odm.annotations.Entry;
 import org.springframework.ldap.odm.core.ObjectDirectoryMapper;
 import org.springframework.ldap.query.LdapQuery;
+import org.springframework.ldap.support.LdapUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -41,10 +54,13 @@ import org.springframework.util.Assert;
  *
  * @author Mattias Hellborg Arthursson
  * @author Mark Paluch
+ * @author Houcheng Lin
  */
 public class SimpleLdapRepository<T> implements LdapRepository<T> {
 
 	private static final String OBJECTCLASS_ATTRIBUTE = "objectclass";
+	private static final String[] ALL_ATTRIBUTES = null;
+	private static final int DEFAULT_PAGE_SIZE = 25;
 
 	private final LdapOperations ldapOperations;
 	private final ObjectDirectoryMapper odm;
@@ -148,6 +164,39 @@ public class SimpleLdapRepository<T> implements LdapRepository<T> {
 	}
 
 	/* (non-Javadoc)
+     * @see org.springframework.data.ldap.repository.LdapRepository#findAll(org.springframework.data.domain.Pageable)
+     */
+	@Override
+	public Page<T> findAll(Pageable pageable) {
+
+		PagedResultsDirContextProcessor pagedContextProcessor = createPagedContext(pageable);
+		ContextMapper<T> mapper = createContextMapper();
+		SearchControls searchControls = createSearchControls();
+		Filter filter = odm.filterFor(entityType, null);
+
+		List<T> content = ldapOperations.search(getBaseAnnotationFromEntityType(), filter.encode(),
+				searchControls, mapper, pagedContextProcessor);
+
+		return createLdapPage(pageable, pagedContextProcessor, content);
+	}
+
+	/* (non-Javadoc)
+     * @see org.springframework.data.ldap.repository.LdapRepository#findAll(org.springframework.ldap.query.LdapQuery, org.springframework.data.domain.Pageable)
+     */
+	@Override
+	public Page<T> findAll(LdapQuery ldapQuery, Pageable pageable) {
+
+		PagedResultsDirContextProcessor pagedContextProcessor = createPagedContext(pageable);
+		ContextMapper<T> mapper = createContextMapper();
+		SearchControls searchControls = createSearchControls();
+
+		List<T> content =  ldapOperations.search(ldapQuery.base(), ldapQuery.filter().encode(), searchControls,
+				mapper, pagedContextProcessor);
+
+		return createLdapPage(pageable, pagedContextProcessor, content);
+	}
+
+	/* (non-Javadoc)
 	 * @see org.springframework.data.ldap.repository.LdapRepository#findOne(org.springframework.ldap.query.LdapQuery)
 	 */
 	@Override
@@ -229,5 +278,126 @@ public class SimpleLdapRepository<T> implements LdapRepository<T> {
 	@Override
 	public void deleteAll() {
 		delete(findAll());
+	}
+
+
+	private PagedResultsDirContextProcessor createPagedContext(Pageable pageable) {
+
+		PagedResultsCookie pagedResultCookie = null;
+		if(pageable instanceof SimpleLdapRepository.LdapPageRequest) {
+			pagedResultCookie = ((LdapPageRequest) pageable).getCookie();
+		}
+
+		int pageSize = (pageable == null) ? DEFAULT_PAGE_SIZE : pageable.getPageSize();
+
+		return new PagedResultsDirContextProcessor(pageSize,
+				pagedResultCookie);
+	}
+
+	private Page<T> createLdapPage(Pageable pageable, PagedResultsDirContextProcessor pagedContextProcessor, List<T> content) {
+
+		LdapPageImpl ldapPageImpl =  new LdapPageImpl(content, pageable, content.size());
+		ldapPageImpl.setContextProcessorForNextPageable(pagedContextProcessor);
+		return ldapPageImpl;
+	}
+
+	private Name getBaseAnnotationFromEntityType() {
+
+		Entry entryAnnotation = entityType.getAnnotation(Entry.class);
+		return (entryAnnotation == null) ? LdapUtils.emptyLdapName() : LdapUtils.newLdapName(entryAnnotation.base());
+	}
+
+	private ContextMapper<T> createContextMapper() {
+
+		return new ContextMapper<T> () {
+			public T mapFromContext(Object ctx) throws NamingException {
+				return odm.mapFromLdapDataEntry((DirContextOperations)ctx, entityType);
+			}
+		};
+	}
+
+	private SearchControls createSearchControls() {
+
+		SearchControls searchControls = new SearchControls();
+		searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+		searchControls.setReturningObjFlag(true);
+		searchControls.setReturningAttributes(ALL_ATTRIBUTES);
+		return searchControls;
+	}
+
+	static class LdapPageImpl<T> extends PageImpl<T> {
+
+		private final Pageable pageable;
+		private PagedResultsCookie cookieForNextPageable;
+		private boolean hasMore;
+
+		LdapPageImpl(List<T> content, Pageable pageable, int total) {
+
+			super(content, pageable, total);
+			this.pageable = pageable;
+		}
+
+		void setContextProcessorForNextPageable(PagedResultsDirContextProcessor contextProcessor) {
+
+			this.cookieForNextPageable = contextProcessor.getCookie();
+			this.hasMore = contextProcessor.hasMore();
+		}
+
+		@Override
+		public Pageable nextPageable() {
+
+			if (hasMore) {
+				LdapPageRequest nextPageable = LdapPageRequest.newInstance(pageable.getPageNumber() + 1, pageable.getPageSize());
+				nextPageable.setCookie(cookieForNextPageable);
+				return nextPageable;
+			}
+
+			return null;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return hasMore;
+		}
+	}
+
+	static class LdapPageRequest extends AbstractPageRequest {
+		private PagedResultsCookie cookie;
+
+		private LdapPageRequest(int page, int size){
+			super(page, size);
+		}
+
+		static LdapPageRequest newInstance(int page, int size) {
+			return new LdapPageRequest(page, size);
+		}
+
+		void setCookie(PagedResultsCookie cookie) {
+			this.cookie = cookie;
+		}
+
+		PagedResultsCookie getCookie() {
+			return cookie;
+		}
+
+		@Override
+		public Sort getSort() {
+			return Sort.unsorted();
+		}
+
+		@Override
+		public Pageable next() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Pageable previous() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Pageable first() {
+			throw new UnsupportedOperationException();
+		}
 	}
 }


### PR DESCRIPTION
This commit adds paging query feature to data LDAP. The following two functions are added into LdapRepository interface:

```
	Page<T> findAll(Pageable pageable);
	Page<T> findAll(LdapQuery ldapQuery, Pageable pageable);
```

The paging query can be easily performed by the following code:
```

    Page<UnitTestPerson> pagedResult = tested.findAll(PageRequest.of(0, 50));
    while(true) {
        processData(pagedResult.getContent());

        if(pagedResult.hasNext()) {
            pagedResult = tested.findAll(pagedResult.nextPageable());
        } else {
            break;
        }
    }
```