### PR TITLE
Remove unnecessary reassignment in LdapQueryCreator

### DIFF
--- a/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryCreator.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryCreator.java
@@ -78,7 +78,7 @@ class LdapQueryCreator extends AbstractQueryCreator<LdapQuery, ContainerCriteria
 		LdapQueryBuilder query = query();
 
 		if (entry != null) {
-			query = query.base(entry.base());
+			query.base(entry.base());
 		}
 
 		ConditionCriteria criteria = query.where(getAttribute(part));


### PR DESCRIPTION
`LdapQueryBuilder#base` returns `this` so there’s no need to reassign it to the `query` variable.
