### PR TITLE
DATALDAP-90 - Remove sudo from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ addons:
     packages:
     - oracle-java8-installer
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Travis CI’s container-based environment will be shutdown soon.

See [their announcement](https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures) for further information.