### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/src/test/resources/infrastructure.xml
+++ b/src/test/resources/infrastructure.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:ldap="http://www.springframework.org/schema/ldap"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/ldap http://www.springframework.org/schema/ldap/spring-ldap.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/ldap https://www.springframework.org/schema/ldap/spring-ldap.xsd">
 
 	<ldap:context-source password="apassword" url="ldap://localhost:389" username="uid=admin"/>
 

--- a/src/test/resources/org/springframework/data/ldap/config/LdapNamespaceHandlerTests-context.xml
+++ b/src/test/resources/org/springframework/data/ldap/config/LdapNamespaceHandlerTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:data-ldap="http://www.springframework.org/schema/data/ldap"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/data/ldap http://www.springframework.org/schema/data/ldap/spring-ldap.xsd">
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/data/ldap https://www.springframework.org/schema/data/ldap/spring-ldap.xsd">
 
 	<import resource="classpath:infrastructure.xml" />
 

--- a/src/test/resources/org/springframework/data/ldap/repository/query/PartTreeLdapRepositoryQueryTests-context.xml
+++ b/src/test/resources/org/springframework/data/ldap/repository/query/PartTreeLdapRepositoryQueryTests-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:data-ldap="http://www.springframework.org/schema/data/ldap"
-		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/data/ldap http://www.springframework.org/schema/data/ldap/spring-ldap.xsd
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/data/ldap https://www.springframework.org/schema/data/ldap/spring-ldap.xsd
 		">
 
 	<import resource="classpath:infrastructure.xml"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.springframework.org/schema/data/ldap/spring-ldap.xsd (404) with 2 occurrences migrated to:  
  https://www.springframework.org/schema/data/ldap/spring-ldap.xsd ([https](https://www.springframework.org/schema/data/ldap/spring-ldap.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/ldap/spring-ldap.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/ldap/spring-ldap.xsd ([https](https://www.springframework.org/schema/ldap/spring-ldap.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 6 occurrences
* http://www.springframework.org/schema/data/ldap with 4 occurrences
* http://www.springframework.org/schema/ldap with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences