### PR TITLE
Add support for custom LDAP parameter encoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-ldap</artifactId>
-	<version>3.5.0-SNAPSHOT</version>
+	<version>3.5.0-GH-509-SNAPSHOT</version>
 
 	<name>Spring Data LDAP</name>
 	<description>Spring Data integration for LDAP</description>

--- a/src/main/java/org/springframework/data/ldap/repository/LdapEncode.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapEncode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
-import org.springframework.data.repository.query.Param;
 
 /**
- * A {@link Param} alias that allows passing of custom {@link LdapEncoder}.
+ * Allows passing of custom {@link LdapEncoder}.
  *
  * @author Marcin Grzejszczak
  * @since 3.5.0
@@ -33,15 +32,22 @@ import org.springframework.data.repository.query.Param;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface LdapParam {
-
-	@AliasFor(annotation = Param.class)
-	String value();
+public @interface LdapEncode {
 
 	/**
 	 * {@link LdapEncoder} to instantiate to encode query parameters.
 	 *
 	 * @return {@link LdapEncoder} class
 	 */
-	Class<? extends LdapEncoder> encoder() default LdapEncoder.DefaultLdapEncoder.class;
+	@AliasFor("encoder")
+	Class<? extends LdapEncoder> value();
+
+	/**
+	 * {@link LdapEncoder} to instantiate to encode query parameters.
+	 *
+	 * @return {@link LdapEncoder} class
+	 */
+	@AliasFor("value")
+	Class<? extends LdapEncoder> encoder() default LdapEncoder.class;
+
 }

--- a/src/main/java/org/springframework/data/ldap/repository/LdapEncode.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapEncode.java
@@ -24,18 +24,28 @@ import java.lang.annotation.Target;
 import org.springframework.core.annotation.AliasFor;
 
 /**
- * Allows passing of custom {@link LdapEncoder}.
+ * Annotation which indicates that a method parameter should be encoded using a specific {@link LdapEncoder} for a
+ * repository query method invocation.
+ * <p>
+ * If no {@link LdapEncoder} is configured, method parameters are encoded using
+ * {@link org.springframework.ldap.support.LdapEncoder#filterEncode(String)}. The default encoder considers chars such
+ * as {@code *} (asterisk) to be encoded which might interfere with the intent of running a Like query. Since Spring
+ * Data LDAP doesn't parse queries it is up to you to decide which encoder to use.
+ * <p>
+ * {@link LdapEncoder} implementations must declare a no-args constructor so they can be instantiated during repository
+ * initialization.
  *
  * @author Marcin Grzejszczak
- * @since 3.5.0
+ * @author Mark Paluch
+ * @since 3.5
  */
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface LdapEncode {
 
 	/**
-	 * {@link LdapEncoder} to instantiate to encode query parameters.
+	 * {@link LdapEncoder} to encode query parameters.
 	 *
 	 * @return {@link LdapEncoder} class
 	 */
@@ -43,7 +53,7 @@ public @interface LdapEncode {
 	Class<? extends LdapEncoder> value();
 
 	/**
-	 * {@link LdapEncoder} to instantiate to encode query parameters.
+	 * {@link LdapEncoder} to encode query parameters.
 	 *
 	 * @return {@link LdapEncoder} class
 	 */

--- a/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
@@ -16,17 +16,25 @@
 package org.springframework.data.ldap.repository;
 
 /**
- * Allows plugging in custom encoding for {@link LdapEncode}.
+ * Strategy interface to escape values for use in LDAP filters.
+ * <p>
+ * Accepts an LDAP filter value to be encoded (escaped) for String-based LDAP query usage as LDAP queries do not feature
+ * an out-of-band parameter binding mechanism.
+ * <p>
+ * Make sure that your implementation escapes special characters in the value adequately to prevent injection attacks.
  *
  * @author Marcin Grzejszczak
- * @since 3.5.0
+ * @author Mark Paluch
+ * @since 3.5
  */
 public interface LdapEncoder {
 
 	/**
-	 * Escape a value for use in a filter.
-	 * @param value the value to escape.
-	 * @return a properly escaped representation of the supplied value.
+	 * Encode a value for use in a filter.
+	 *
+	 * @param value the value to encode.
+	 * @return a properly encoded representation of the supplied value.
 	 */
-	String filterEncode(String value);
+	String encode(String value);
+
 }

--- a/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.ldap.repository;
+
+/**
+ * Allows plugging in custom encoding for {@link LdapParam}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 3.5.0
+ */
+public interface LdapEncoder {
+
+	/**
+	 * Escape a value for use in a filter.
+	 * @param value the value to escape.
+	 * @return a properly escaped representation of the supplied value.
+	 */
+	String filterEncode(String value);
+
+	/**
+	 * Default implementation of {@link LdapEncoder} that uses
+	 * {@link org.springframework.ldap.support.LdapEncoder}.
+	 */
+	class DefaultLdapEncoder implements LdapEncoder {
+
+		@Override
+		public String filterEncode(String value) {
+			return org.springframework.ldap.support.LdapEncoder.filterEncode(value);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapEncoder.java
@@ -16,7 +16,7 @@
 package org.springframework.data.ldap.repository;
 
 /**
- * Allows plugging in custom encoding for {@link LdapParam}.
+ * Allows plugging in custom encoding for {@link LdapEncode}.
  *
  * @author Marcin Grzejszczak
  * @since 3.5.0
@@ -29,17 +29,4 @@ public interface LdapEncoder {
 	 * @return a properly escaped representation of the supplied value.
 	 */
 	String filterEncode(String value);
-
-	/**
-	 * Default implementation of {@link LdapEncoder} that uses
-	 * {@link org.springframework.ldap.support.LdapEncoder}.
-	 */
-	class DefaultLdapEncoder implements LdapEncoder {
-
-		@Override
-		public String filterEncode(String value) {
-			return org.springframework.ldap.support.LdapEncoder.filterEncode(value);
-		}
-	}
-
 }

--- a/src/main/java/org/springframework/data/ldap/repository/LdapParam.java
+++ b/src/main/java/org/springframework/data/ldap/repository/LdapParam.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.ldap.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * A {@link Param} alias that allows passing of custom {@link LdapEncoder}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 3.5.0
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LdapParam {
+
+	@AliasFor(annotation = Param.class)
+	String value();
+
+	/**
+	 * {@link LdapEncoder} to instantiate to encode query parameters.
+	 *
+	 * @return {@link LdapEncoder} class
+	 */
+	Class<? extends LdapEncoder> encoder() default LdapEncoder.DefaultLdapEncoder.class;
+}

--- a/src/main/java/org/springframework/data/ldap/repository/query/LdapParameters.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/LdapParameters.java
@@ -20,13 +20,10 @@ import java.util.List;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.data.geo.Distance;
-import org.springframework.data.ldap.repository.LdapEncoder;
-import org.springframework.data.ldap.repository.LdapParam;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersSource;
 import org.springframework.data.util.TypeInformation;
-import org.springframework.lang.Nullable;
 
 /**
  * Custom extension of {@link Parameters} discovering additional
@@ -62,33 +59,15 @@ public class LdapParameters extends Parameters<LdapParameters, LdapParameters.Ld
 		return new LdapParameters(parameters, this.domainType);
 	}
 
-	@Nullable
-	LdapEncoder encoderForParameterWithName(String parameterName) {
-		for (LdapParameter parameter : this) {
-			if (parameterName.equals(parameter.getName().orElse(null))) {
-				LdapParam ldapParam = parameter.parameter.getParameterAnnotation(LdapParam.class);
-				if (ldapParam == null) {
-					return null;
-				}
-				Class<? extends LdapEncoder> encoder = ldapParam.encoder();
-				try {
-					return encoder.getDeclaredConstructor().newInstance();
-				} catch (Exception e) {
-					throw new IllegalStateException(e);
-				}
-			}
-		}
-		return null;
-	}
 
 	/**
 	 * Custom {@link Parameter} implementation adding parameters of type {@link Distance} to the special ones.
 	 *
 	 * @author Marcin Grzejszczak
 	 */
-	protected static class LdapParameter extends Parameter {
+	static class LdapParameter extends Parameter {
 
-		private final MethodParameter parameter;
+		final MethodParameter parameter;
 
 		/**
 		 * Creates a new {@link LdapParameter}.

--- a/src/main/java/org/springframework/data/ldap/repository/query/LdapParameters.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/LdapParameters.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.ldap.repository.query;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.ldap.repository.LdapEncoder;
+import org.springframework.data.ldap.repository.LdapParam;
+import org.springframework.data.repository.query.Parameter;
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.ParametersSource;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.lang.Nullable;
+
+/**
+ * Custom extension of {@link Parameters} discovering additional
+ *
+ * @author Marcin Grzejszczak
+ * @since 3.5.0
+ */
+public class LdapParameters extends Parameters<LdapParameters, LdapParameters.LdapParameter> {
+
+	private final TypeInformation<?> domainType;
+
+	/**
+	 * Creates a new {@link LdapParameters} instance from the given {@link Method} and {@link LdapQueryMethod}.
+	 *
+	 * @param parametersSource must not be {@literal null}.
+	 */
+	public LdapParameters(ParametersSource parametersSource) {
+
+		super(parametersSource, methodParameter -> new LdapParameter(methodParameter,
+				parametersSource.getDomainTypeInformation()));
+
+		this.domainType = parametersSource.getDomainTypeInformation();
+	}
+
+	private LdapParameters(List<LdapParameter> parameters, TypeInformation<?> domainType) {
+
+		super(parameters);
+		this.domainType = domainType;
+	}
+
+	@Override
+	protected LdapParameters createFrom(List<LdapParameter> parameters) {
+		return new LdapParameters(parameters, this.domainType);
+	}
+
+	@Nullable
+	LdapEncoder encoderForParameterWithName(String parameterName) {
+		for (LdapParameter parameter : this) {
+			if (parameterName.equals(parameter.getName().orElse(null))) {
+				LdapParam ldapParam = parameter.parameter.getParameterAnnotation(LdapParam.class);
+				if (ldapParam == null) {
+					return null;
+				}
+				Class<? extends LdapEncoder> encoder = ldapParam.encoder();
+				try {
+					return encoder.getDeclaredConstructor().newInstance();
+				} catch (Exception e) {
+					throw new IllegalStateException(e);
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Custom {@link Parameter} implementation adding parameters of type {@link Distance} to the special ones.
+	 *
+	 * @author Marcin Grzejszczak
+	 */
+	protected static class LdapParameter extends Parameter {
+
+		private final MethodParameter parameter;
+
+		/**
+		 * Creates a new {@link LdapParameter}.
+		 *
+		 * @param parameter must not be {@literal null}.
+		 * @param domainType must not be {@literal null}.
+		 */
+		LdapParameter(MethodParameter parameter, TypeInformation<?> domainType) {
+			super(parameter, domainType);
+			this.parameter = parameter;
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryMethod.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryMethod.java
@@ -21,7 +21,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.ldap.repository.Query;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.ParametersSource;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.lang.Nullable;
@@ -48,6 +47,16 @@ public class LdapQueryMethod extends QueryMethod {
 		super(method, metadata, factory);
 
 		this.method = method;
+	}
+
+	@Override
+	protected LdapParameters createParameters(ParametersSource parametersSource) {
+		return new LdapParameters(parametersSource);
+	}
+
+	@Override
+	public LdapParameters getParameters() {
+		return (LdapParameters) super.getParameters();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/ldap/repository/query/StringBasedQuery.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/StringBasedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 the original author or authors.
+ * Copyright 2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.ldap.repository.query;
 
+import static org.springframework.data.ldap.repository.query.StringBasedQuery.BindingContext.*;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -25,10 +27,8 @@ import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.springframework.beans.BeanUtils;
 import org.springframework.data.expression.ValueExpression;
 import org.springframework.data.expression.ValueExpressionParser;
-import org.springframework.data.ldap.repository.LdapEncode;
 import org.springframework.data.repository.query.Parameter;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.Parameters;
@@ -39,12 +39,11 @@ import org.springframework.ldap.support.LdapEncoder;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import static org.springframework.data.ldap.repository.query.StringBasedQuery.BindingContext.ParameterBinding;
-
 /**
  * String-based Query abstracting a query with parameter bindings.
  *
  * @author Marcin Grzejszczak
+ * @author Mark Paluch
  * @since 3.4
  */
 class StringBasedQuery {
@@ -358,15 +357,19 @@ class StringBasedQuery {
 			if (binding.isExpression()) {
 				return evaluator.apply(binding.getRequiredExpression());
 			}
-			Object value = binding.isNamed()
-					? parameterAccessor.getBindableValue(getParameterIndex(parameters, binding.getRequiredParameterName()))
-					: parameterAccessor.getBindableValue(binding.getParameterIndex());
+			int index = binding.isNamed() ? getParameterIndex(parameters, binding.getRequiredParameterName())
+					: binding.getParameterIndex();
+			Object value = parameterAccessor.getBindableValue(index);
 
 			if (value == null) {
 				return null;
 			}
 
-			return binding.getEncodedValue(parameters, value);
+			String toString = value.toString();
+			LdapParameters.LdapParameter parameter = parameters.getBindableParameter(index);
+
+			return parameter.hasLdapEncoder() ? parameter.getLdapEncoder().encode(toString)
+					: LdapEncoder.filterEncode(toString);
 		}
 
 		private int getParameterIndex(Parameters<?, ?> parameters, String parameterName) {
@@ -411,38 +414,6 @@ class StringBasedQuery {
 
 			static ParameterBinding named(String name) {
 				return new ParameterBinding(-1, null, name);
-			}
-
-			Object getEncodedValue(LdapParameters ldapParameters, Object value) {
-				org.springframework.data.ldap.repository.LdapEncoder encoder = encoderForParameter(ldapParameters);
-				if (encoder == null) {
-					return LdapEncoder.filterEncode(value.toString());
-				}
-				return encoder.filterEncode(value.toString());
-			}
-
-
-			@Nullable
-			org.springframework.data.ldap.repository.LdapEncoder encoderForParameter(LdapParameters ldapParameters) {
-				for (LdapParameters.LdapParameter parameter : ldapParameters) {
-					if (isByName(parameter) || isByIndex(parameter)) {
-						LdapEncode ldapEncode = parameter.parameter.getParameterAnnotation(LdapEncode.class);
-						if (ldapEncode == null) {
-							return null;
-						}
-						Class<? extends org.springframework.data.ldap.repository.LdapEncoder> encoder = ldapEncode.value();
-						return BeanUtils.instantiateClass(encoder);
-					}
-				}
-				return null;
-			}
-
-			private boolean isByIndex(LdapParameters.LdapParameter parameter) {
-				return parameterIndex != -1 && parameter.getIndex() == parameterIndex;
-			}
-
-			private boolean isByName(LdapParameters.LdapParameter parameter) {
-				return parameterName != null && parameterName.equals(parameter.getName().orElse(null));
 			}
 
 			boolean isNamed() {

--- a/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
@@ -15,14 +15,16 @@
  */
 package org.springframework.data.ldap.repository.query;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.data.ldap.core.mapping.LdapMappingContext;
-import org.springframework.data.ldap.repository.LdapEncoder;
 import org.springframework.data.ldap.repository.LdapEncode;
+import org.springframework.data.ldap.repository.LdapEncoder;
 import org.springframework.data.ldap.repository.LdapRepository;
 import org.springframework.data.ldap.repository.Query;
 import org.springframework.data.mapping.model.EntityInstantiators;
@@ -31,8 +33,6 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
 import org.springframework.data.repository.query.ValueExpressionDelegate;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.query.LdapQuery;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link AnnotatedLdapRepositoryQuery}
@@ -122,7 +122,7 @@ class AnnotatedLdapRepositoryQueryUnitTests {
 	static class MyEncoder implements LdapEncoder {
 
 		@Override
-		public String filterEncode(String value) {
+		public String encode(String value) {
 			return value + "bar";
 		}
 	}

--- a/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.data.ldap.repository.query;
 
-import static org.assertj.core.api.Assertions.*;
-
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.data.ldap.core.mapping.LdapMappingContext;
+import org.springframework.data.ldap.repository.LdapEncoder;
+import org.springframework.data.ldap.repository.LdapParam;
 import org.springframework.data.ldap.repository.LdapRepository;
 import org.springframework.data.ldap.repository.Query;
 import org.springframework.data.mapping.model.EntityInstantiators;
@@ -31,6 +31,8 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
 import org.springframework.data.repository.query.ValueExpressionDelegate;
 import org.springframework.ldap.core.LdapOperations;
 import org.springframework.ldap.query.LdapQuery;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link AnnotatedLdapRepositoryQuery}
@@ -79,6 +81,18 @@ class AnnotatedLdapRepositoryQueryUnitTests {
 		assertThat(ldapQuery.base()).hasToString("cn=John\\29");
 	}
 
+	@Test
+	void shouldEncodeWithCustomEncoder() throws NoSuchMethodException {
+
+		LdapQueryMethod method = queryMethod("customEncoder", String.class);
+		AnnotatedLdapRepositoryQuery query = repositoryQuery(method);
+
+		LdapQuery ldapQuery = query.createQuery(
+				new LdapParametersParameterAccessor(method, new Object[] { "Doe" }));
+
+		assertThat(ldapQuery.filter().encode()).isEqualTo("(cn=Doebar)");
+	}
+
 	private LdapQueryMethod queryMethod(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
 		return new LdapQueryMethod(QueryRepository.class.getMethod(methodName, parameterTypes),
 				new DefaultRepositoryMetadata(QueryRepository.class), new SpelAwareProxyProjectionFactory());
@@ -100,5 +114,16 @@ class AnnotatedLdapRepositoryQueryUnitTests {
 		@Query(base = ":dc", value = "(cn=:fullName)")
 		List<SchemaEntry> baseNamedParameters(String fullName, String dc);
 
+		@Query(value = "(cn=:fullName)")
+		List<SchemaEntry> customEncoder(@LdapParam(value = "fullName", encoder = MyEncoder.class) String fullName);
+
+	}
+
+	static class MyEncoder implements LdapEncoder {
+
+		@Override
+		public String filterEncode(String value) {
+			return value + "bar";
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/ldap/repository/query/AnnotatedLdapRepositoryQueryUnitTests.java
@@ -22,7 +22,7 @@ import org.mockito.Mockito;
 
 import org.springframework.data.ldap.core.mapping.LdapMappingContext;
 import org.springframework.data.ldap.repository.LdapEncoder;
-import org.springframework.data.ldap.repository.LdapParam;
+import org.springframework.data.ldap.repository.LdapEncode;
 import org.springframework.data.ldap.repository.LdapRepository;
 import org.springframework.data.ldap.repository.Query;
 import org.springframework.data.mapping.model.EntityInstantiators;
@@ -115,7 +115,7 @@ class AnnotatedLdapRepositoryQueryUnitTests {
 		List<SchemaEntry> baseNamedParameters(String fullName, String dc);
 
 		@Query(value = "(cn=:fullName)")
-		List<SchemaEntry> customEncoder(@LdapParam(value = "fullName", encoder = MyEncoder.class) String fullName);
+		List<SchemaEntry> customEncoder(@LdapEncode(MyEncoder.class) String fullName);
 
 	}
 


### PR DESCRIPTION
Add `@LdapEncode` annotation to specify a custom LDAP parameter encoder.