### PR TITLE
Fix projection query field mapping issue

### DIFF
--- a/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryCreator.java
+++ b/src/main/java/org/springframework/data/ldap/repository/query/LdapQueryCreator.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  *
  * @author Mattias Hellborg Arthursson
  * @author Mark Paluch
+ * @author Xiangcheng Kuo
  */
 class LdapQueryCreator extends AbstractQueryCreator<LdapQuery, ContainerCriteria> {
 
@@ -80,7 +81,7 @@ class LdapQueryCreator extends AbstractQueryCreator<LdapQuery, ContainerCriteria
 		}
 
 		if (!inputProperties.isEmpty()) {
-			query.attributes(inputProperties.toArray(new String[0]));
+			query.attributes(inputProperties.stream().map(prop -> mapper.attributeFor(entityType, prop)).toList().toArray(new String[0]));
 		}
 
 		ConditionCriteria criteria = query.where(getAttribute(part));

--- a/src/test/java/org/springframework/data/ldap/repository/LdapRepositoryUnitTests.java
+++ b/src/test/java/org/springframework/data/ldap/repository/LdapRepositoryUnitTests.java
@@ -78,7 +78,7 @@ class LdapRepositoryUnitTests {
 		verify(ldapOperations).findOne(captor.capture(), any());
 
 		LdapQuery query = captor.getValue();
-		assertThat(query.attributes()).containsOnly("lastName");
+		assertThat(query.attributes()).containsOnly("sn");
 	}
 
 	@Test
@@ -96,7 +96,7 @@ class LdapRepositoryUnitTests {
 		verify(ldapOperations).findOne(captor.capture(), any());
 
 		LdapQuery query = captor.getValue();
-		assertThat(query.attributes()).contains("lastName");
+		assertThat(query.attributes()).contains("sn");
 	}
 
 	@Test
@@ -115,7 +115,7 @@ class LdapRepositoryUnitTests {
 		verify(ldapOperations).find(captor.capture(), any());
 
 		LdapQuery query = captor.getValue();
-		assertThat(query.attributes()).containsOnly("lastName");
+		assertThat(query.attributes()).containsOnly("sn");
 	}
 
 	interface PersonRepository extends LdapRepository<UnitTestPerson> {


### PR DESCRIPTION
When using projection queries with entities that have @Attribute annotations for LDAP field mapping, the query was using Java field names instead of the mapped LDAP attribute names. This caused queries to fail when the Java field name differs from the LDAP attribute name.

Changes:
- Modified LdapQueryCreator to map projection fields using ObjectDirectoryMapper.attributeFor() method
- - Updated test assertions to verify correct LDAP attribute names are used in queries (e.g., "sn" instead of "lastName")
Example: For an entity field 'groupId' mapped to LDAP attribute 'gidNumber' via @Attribute annotation, projection queries now correctly use 'gidNumber' in the LDAP query.

Fixes projection queries for entities with custom LDAP attribute mappings.

<!-- Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request. Make sure that: -->
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don't submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).