### PR TITLE
Add support for the Querydsl IN operator in LdapSerializer.

### DIFF
--- a/src/main/java/org/springframework/data/ldap/repository/support/LdapSerializer.java
+++ b/src/main/java/org/springframework/data/ldap/repository/support/LdapSerializer.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.ldap.repository.support;
 
+import java.util.Collection;
+
 import org.springframework.ldap.filter.AndFilter;
 import org.springframework.ldap.filter.EqualsFilter;
 import org.springframework.ldap.filter.Filter;
@@ -33,6 +35,7 @@ import com.querydsl.core.types.*;
  *
  * @author Mattias Hellborg Arthursson
  * @author Eddu Melendez
+ * @author Ashish Vaghela
  */
 class LdapSerializer implements Visitor<Object, Void> {
 
@@ -94,9 +97,33 @@ class LdapSerializer implements Visitor<Object, Void> {
 			return new GreaterThanOrEqualsFilter(attribute(expr), value(expr));
 		} else if (operator == Ops.LOE) {
 			return new LessThanOrEqualsFilter(attribute(expr), value(expr));
+		} else if (operator == Ops.IN) {
+			return inFilter(expr);
 		}
 
 		throw new UnsupportedOperationException("Unsupported operator " + operator.toString());
+	}
+
+	private Filter inFilter(Operation<?> expr) {
+
+		if (expr.getArg(1) instanceof Path) {
+			String attribute = odm.attributeFor(entityType, (String) expr.getArg(1).accept(this, null));
+			return new EqualsFilter(attribute, (String) expr.getArg(0).accept(this, null));
+		}
+
+		if (expr.getArg(1) instanceof Constant<?> constant && constant.getConstant() instanceof Collection<?> values) {
+
+			String attribute = attribute(expr);
+			OrFilter filter = new OrFilter();
+
+			for (Object value : values) {
+				filter.or(new EqualsFilter(attribute, value.toString()));
+			}
+
+			return filter;
+		}
+
+		throw new UnsupportedOperationException("Unsupported operand for IN operator: " + expr.getArg(1));
 	}
 
 	private String value(Operation<?> expr) {

--- a/src/test/java/org/springframework/data/ldap/repository/support/QuerydslFilterGeneratorTests.java
+++ b/src/test/java/org/springframework/data/ldap/repository/support/QuerydslFilterGeneratorTests.java
@@ -27,6 +27,7 @@ import com.querydsl.core.types.Expression;
 /**
  * @author Mattias Hellborg Arthursson
  * @author Eddu Melendez
+ * @author Ashish Vaghela
  */
 class QuerydslFilterGeneratorTests {
 
@@ -133,5 +134,32 @@ class QuerydslFilterGeneratorTests {
 		Filter result = tested.handle(expression);
 
 		assertThat(result).hasToString("(!(cn=*))");
+	}
+
+	@Test // GH-82
+	void testCollectionContains() {
+
+		Expression<?> expression = person.description.contains("test");
+		Filter result = tested.handle(expression);
+
+		assertThat(result).hasToString("(description=test)");
+	}
+
+	@Test // GH-82
+	void testIn() {
+
+		Expression<?> expression = person.fullName.in("John Doe", "Jane Doe");
+		Filter result = tested.handle(expression);
+
+		assertThat(result).hasToString("(|(cn=John Doe)(cn=Jane Doe))");
+	}
+
+	@Test // GH-82
+	void testInWithSingleValue() {
+
+		Expression<?> expression = person.fullName.in("John Doe");
+		Filter result = tested.handle(expression);
+
+		assertThat(result).hasToString("(cn=John Doe)");
 	}
 }


### PR DESCRIPTION
Closes #82

Using a Querydsl predicate on a multi-valued attribute, e.g.:

```java
QPerson person = QPerson.person;
repository.findAll(person.studentAliases.contains(alias));
```

fails with:

```
java.lang.UnsupportedOperationException: Unsupported operator IN
at org.springframework.data.ldap.repository.support.LdapSerializer.visit(LdapSerializer.java:99)
```

Querydsl translates `collectionPath.contains(value)` into an `Ops.IN` operation, which `LdapSerializer` did not handle.

This PR adds `Ops.IN` handling for both shapes Querydsl produces:

- `collectionPath.contains(value)` emitted as `IN(element, path)` maps to `(attribute=value)`, since LDAP equality on a multi-valued attribute matches if any value is equal.
- `path.in(a, b)` emitted as `IN(path, constantCollection)` maps to `(|(attribute=a)(attribute=b))`.

`path.in(singleValue)` already worked because Querydsl rewrites it to `eq`; a test now pins that behavior.

Tests were written first and confirmed failing on unmodified `main` with the exact exception from the issue, then made green by the change. The new tests reuse the existing `QPerson` / `UnitTestPerson` fixtures (the `description` attribute is already multi-valued). Full test suite passes: 86 tests, 0 failures.

- [x] You have read the Spring Data contribution guidelines.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched.